### PR TITLE
CSP whitelist for Google map URL

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="style-src">
+            <values>
+                <value id="style-googleapis" type="host">https://fonts.googleapis.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="connect-googleapis" type="host">https://maps.googleapis.com/</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="img-googleapis" type="host">https://maps.googleapis.com/</value>
+            </values>
+        </policy>
+        <policy id="script-src">
+            <values>
+                <value id="script-googleapis" type="host">https://maps.googleapis.com/</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
### Description (*)
Adding csp_whitelist.xml to avoid content blocking in restrict mode

### Manual testing scenarios (*)
1. Add Mageplaza Google Maps widget on a fronted page
2. Observe console for CSP errors